### PR TITLE
Deeplink mIsUnique assigned to itself

### DIFF
--- a/hoko/src/main/java/com/hokolinks/model/Deeplink.java
+++ b/hoko/src/main/java/com/hokolinks/model/Deeplink.java
@@ -70,7 +70,7 @@ public class Deeplink {
         mURLs = new HashMap<>();
         mDeeplinkURL = deeplinkURL;
         mIsDeferred = isDeferred;
-        mIsUnique = mIsUnique;
+        mIsUnique = isUnique;
     }
 
     /**


### PR DESCRIPTION
Fix Deeplink constructor call where you would assign mIsUnique to itself instead of to the one from constructor
